### PR TITLE
Implemented functionality to get own learning days

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,18 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.hamcrest</groupId>
+					<artifactId>hamcrest-core</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>1.4.200</version>
@@ -82,6 +94,11 @@
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt</artifactId>
 			<version>0.9.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.modelmapper</groupId>
+			<artifactId>modelmapper</artifactId>
+			<version>2.3.5</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/VU/PSKProject/Config/WebConfig.java
+++ b/src/main/java/com/VU/PSKProject/Config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.VU.PSKProject.Config;
 
+import org.modelmapper.ModelMapper;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,5 +23,10 @@ public class WebConfig implements WebMvcConfigurer {
         ServletRegistrationBean registrationBean = new ServletRegistrationBean( new WebServlet());
         registrationBean.addUrlMappings("/h2-console/*");
         return registrationBean;
+    }
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
     }
 }

--- a/src/main/java/com/VU/PSKProject/Controller/LearningDayController.java
+++ b/src/main/java/com/VU/PSKProject/Controller/LearningDayController.java
@@ -25,11 +25,20 @@ public class LearningDayController {
         return learningDayService.getAllLearningDaysByWorkerId(workerId);
     }
 
+    @GetMapping("/get/{year}/{month}/{workerId}")
+    public List<LearningDayDTO> getMonthLearningDaysByWorkerId(
+        @PathVariable String year,
+        @PathVariable String month,
+        @PathVariable Long workerId
+    ) {
+        return learningDayService.getMonthLearningDaysByWorkerId(year, month, workerId);
+    }
+
     @PostMapping("/create")
     public void createLearningEventForWorker(@RequestBody LearningDayDTO learningDayDto) {
         LearningDay learningDay = new LearningDay();
         BeanUtils.copyProperties(learningDayDto, learningDay);
-        workerService.getWorker(learningDayDto.getAssignee()).ifPresent(learningDay::setAssignee);
+        workerService.getWorker(learningDayDto.getAssignee().getId()).ifPresent(learningDay::setAssignee);
         learningDayService.createLearningDay(learningDay);
     }
 
@@ -37,7 +46,7 @@ public class LearningDayController {
     public void updateLearningEvent(@RequestBody LearningDayDTO learningDayDto, @PathVariable Long id) {
         LearningDay learningDay = new LearningDay();
         BeanUtils.copyProperties(learningDayDto, learningDay);
-        workerService.getWorker(learningDayDto.getAssignee()).ifPresent(learningDay::setAssignee);
+        workerService.getWorker(learningDayDto.getAssignee().getId()).ifPresent(learningDay::setAssignee);
         learningDayService.updateLearningDay(learningDay, id);
     }
     @DeleteMapping("/delete/{id}")

--- a/src/main/java/com/VU/PSKProject/Entity/LearningDay.java
+++ b/src/main/java/com/VU/PSKProject/Entity/LearningDay.java
@@ -22,10 +22,7 @@ public class LearningDay {
     private String comment;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-    private Timestamp startAt;
-
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-    private Timestamp endAt;
+    private Timestamp dateTimeAt;
 
     @NotNull
     @ManyToOne(cascade = CascadeType.ALL)

--- a/src/main/java/com/VU/PSKProject/PskProjectApplication.java
+++ b/src/main/java/com/VU/PSKProject/PskProjectApplication.java
@@ -16,11 +16,12 @@ public class PskProjectApplication {
 		SpringApplication.run(PskProjectApplication.class, args);
 	}
 
-
 	//TODO: This method is for dev testing only, will need to be removed later
 	// Add more users if neccessary
 	@Bean
 	public ApplicationRunner initializer(UserRepository repository) {
+		repository.deleteAll();
+
 		return args -> repository.saveAll(Arrays.asList(
 				new User(
 						"admin",

--- a/src/main/java/com/VU/PSKProject/Repository/LearningDayRepository.java
+++ b/src/main/java/com/VU/PSKProject/Repository/LearningDayRepository.java
@@ -2,12 +2,12 @@ package com.VU.PSKProject.Repository;
 
 import com.VU.PSKProject.Entity.LearningDay;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
+import java.sql.Timestamp;
 import java.util.List;
 
 public interface LearningDayRepository extends JpaRepository<LearningDay, Long> {
-    @Query("select le from learning_day le where le.assignee.id = :workerId")
-    List<LearningDay> findAllLearningDaysByWorkerId(@Param("workerId") Long workerId);
+    List<LearningDay> findAllByAssigneeId(Long workerId);
+
+    List<LearningDay> findAllByDateTimeAtBetweenAndAssigneeId(Timestamp dateFrom, Timestamp dateTo, Long workerId);
 }

--- a/src/main/java/com/VU/PSKProject/Service/AuthenticationService.java
+++ b/src/main/java/com/VU/PSKProject/Service/AuthenticationService.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 
 public class AuthenticationService {
+    //TODO: shorten this when app goes live
     static final long EXPIRATIONTIME = 900000000;
     static final String SIGNINGKEY = "signingKey";
     static final String BEARER_PREFIX = "Bearer";

--- a/src/main/java/com/VU/PSKProject/Service/LearningDayService.java
+++ b/src/main/java/com/VU/PSKProject/Service/LearningDayService.java
@@ -2,19 +2,37 @@ package com.VU.PSKProject.Service;
 
 import com.VU.PSKProject.Entity.LearningDay;
 import com.VU.PSKProject.Repository.LearningDayRepository;
+import com.VU.PSKProject.Service.Mapper.LearningDayMapper;
 import com.VU.PSKProject.Service.Model.LearningDayDTO;
+import com.VU.PSKProject.Utils.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.sql.Timestamp;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class LearningDayService {
     @Autowired
     private LearningDayRepository learningDayRepository;
 
+    @Autowired
+    private LearningDayMapper learningDayMapper;
+
+
     public List<LearningDay> getAllLearningDaysByWorkerId(Long workerId) {
-        return learningDayRepository.findAllLearningDaysByWorkerId(workerId);
+        return learningDayRepository.findAllByAssigneeId(workerId);
+    }
+
+    public List<LearningDayDTO> getMonthLearningDaysByWorkerId(String year, String month, Long workerId){
+        Timestamp dateFrom = Timestamp.valueOf(DateUtils.stringsToDate(year, month, "1").minusDays(7));
+        String lastDay = DateUtils.getLastDayOfMonth(year, month);
+        Timestamp dateTo = Timestamp.valueOf(DateUtils.stringsToDate(year, month, lastDay).plusDays(7));
+        return learningDayRepository.findAllByDateTimeAtBetweenAndAssigneeId(dateFrom, dateTo, workerId)
+                .stream()
+                .map(learningDayMapper::toDTO)
+                .collect(Collectors.toList());
     }
 
     public void createLearningDay(LearningDay learningDay) {

--- a/src/main/java/com/VU/PSKProject/Service/Mapper/LearningDayMapper.java
+++ b/src/main/java/com/VU/PSKProject/Service/Mapper/LearningDayMapper.java
@@ -1,0 +1,18 @@
+package com.VU.PSKProject.Service.Mapper;
+
+import com.VU.PSKProject.Entity.LearningDay;
+import com.VU.PSKProject.Service.Model.LearningDayDTO;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LearningDayMapper {
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    public LearningDayDTO toDTO(LearningDay learningDay) {
+        return modelMapper.map(learningDay, LearningDayDTO.class);
+    }
+}

--- a/src/main/java/com/VU/PSKProject/Service/Model/LearningDayAssigneeDTO.java
+++ b/src/main/java/com/VU/PSKProject/Service/Model/LearningDayAssigneeDTO.java
@@ -1,0 +1,10 @@
+package com.VU.PSKProject.Service.Model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LearningDayAssigneeDTO {
+    private Long id;
+}

--- a/src/main/java/com/VU/PSKProject/Service/Model/LearningDayDTO.java
+++ b/src/main/java/com/VU/PSKProject/Service/Model/LearningDayDTO.java
@@ -12,9 +12,7 @@ public class LearningDayDTO {
     private Long id;
     private String name;
     private String comment;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-    private Timestamp startAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-    private Timestamp endAt;
-    private Long assignee;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Europe/Vilnius")
+    private Timestamp dateTimeAt;
+    private LearningDayAssigneeDTO assignee;
 }

--- a/src/main/java/com/VU/PSKProject/Utils/DateUtils.java
+++ b/src/main/java/com/VU/PSKProject/Utils/DateUtils.java
@@ -1,0 +1,23 @@
+package com.VU.PSKProject.Utils;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+
+public class DateUtils {
+
+    private DateUtils(){
+        throw new IllegalStateException("Util class");
+    }
+
+    public static LocalDateTime stringsToDate(String year, String month, String day) {
+        return LocalDateTime.of(Integer.parseInt(year), Integer.parseInt(month), Integer.parseInt(day), 0, 0);
+    }
+
+    public static String getLastDayOfMonth(String year, String month) {
+        return YearMonth.of(Integer.parseInt(year) , Integer.parseInt(month))
+                .atEndOfMonth()
+                .format(DateTimeFormatter.ofPattern("d"));
+    }
+}

--- a/src/main/psk-ui/src/api/calendar-service.ts
+++ b/src/main/psk-ui/src/api/calendar-service.ts
@@ -1,0 +1,28 @@
+import { CancelSource } from './cancel-source';
+import { RestService } from './rest-service';
+import { LearningDayRequest } from './model/learning-day-request';
+import { AxiosResponse } from 'axios';
+import { LearningEvent } from '../models/learningEvent';
+
+class CalendarService {
+    private readonly restService: RestService;
+
+    constructor(cancelSource: CancelSource = new CancelSource()) {
+    	this.restService = cancelSource.service;
+    }
+
+    public getMonthLearningDays = (request: LearningDayRequest): Promise<LearningEvent[]> => {
+    	return this.restService
+    		.get<LearningEvent[]>(
+    			`/learningDays/get/${request.selectedYear}/${request.selectedMonth}/${request.workerId}`
+    		)
+    		.then((response: AxiosResponse<LearningEvent[]>) => {
+    			return response.data;
+    		});
+    }; 
+}
+
+const calendarService = new CalendarService();
+
+export { CalendarService };
+export { calendarService as default };

--- a/src/main/psk-ui/src/api/model/learning-day-request.ts
+++ b/src/main/psk-ui/src/api/model/learning-day-request.ts
@@ -1,0 +1,5 @@
+export interface LearningDayRequest {
+    workerId: number;
+    selectedMonth: string;
+    selectedYear: string;
+}

--- a/src/main/psk-ui/src/api/model/learning-day-response.ts
+++ b/src/main/psk-ui/src/api/model/learning-day-response.ts
@@ -1,0 +1,9 @@
+export interface LearningDayResponse {
+    id: number;
+    name: string;
+    comment: string;
+    dateTimeAt: string;
+    assignee: {
+        id: number;
+    };
+}

--- a/src/main/psk-ui/src/api/rest-service.ts
+++ b/src/main/psk-ui/src/api/rest-service.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosPromise, AxiosRequestConfig, CancelTokenSource } from 'axios';
+import { store } from '../redux/store';
 
 export interface RestServiceConfig {
     cancelTokenSource: CancelTokenSource;
@@ -15,29 +16,43 @@ class RestService {
     	this.cancelTokenSource = config.cancelTokenSource;
     	this.axiosInstance = axios.create({
     		baseURL: '/api',
-    		cancelToken: this.cancelTokenSource.token
+    		cancelToken: this.cancelTokenSource.token,
     	});
     }
 
     public get<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T> {
-    	return this.axiosInstance.get(url, config);
+    	return this.axiosInstance.get(url, appendAuthorizationHeader(config, getCurrentJWT()));
     }
 
     public save<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T> {
-    	return this.axiosInstance.post(url, data, config);
+    	return this.axiosInstance.post(url, data, appendAuthorizationHeader(config, getCurrentJWT()));
     }
 
     public delete<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T> {
-    	return this.axiosInstance.delete(url, config);
+    	return this.axiosInstance.delete(url, appendAuthorizationHeader(config, getCurrentJWT()));
     }
 
     public update<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T> {
-    	return this.axiosInstance.put(url, data, config);
+    	return this.axiosInstance.put(url, data, appendAuthorizationHeader(config, getCurrentJWT()));
     }
 
     public patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T> {
-    	return this.axiosInstance.patch(url, data, config);
+    	return this.axiosInstance.patch(url, data, appendAuthorizationHeader(config, getCurrentJWT()));
     }
+}
+
+function getCurrentJWT(): string {
+	return store.store.getState().user.token;
+}
+
+function appendAuthorizationHeader( config: AxiosRequestConfig | undefined, headers: string): AxiosRequestConfig {
+	return {
+		...config,
+		headers: {
+			...config?.headers,
+			Authorization: headers
+		}
+	};
 }
 
 export { RestService };

--- a/src/main/psk-ui/src/index.tsx
+++ b/src/main/psk-ui/src/index.tsx
@@ -5,20 +5,15 @@ import { App } from './App';
 import * as serviceWorker from './serviceWorker';
 import { Router } from 'react-router-dom';
 import history from './history';
-import configureStore from './redux';
 import 'antd/dist/antd.css';
 import './index.css';
 import { PersistGate } from 'redux-persist/integration/react';
-
-const {
-	store,
-	persistedStore
-} = configureStore();
+import { store } from './redux/store';
 
 
 ReactDOM.render(
-	<Provider store={store}>
-		<PersistGate persistor={persistedStore}>
+	<Provider store={store.store}>
+		<PersistGate persistor={store.persistedStore}>
 			<Router history={history}>
 				<App/>
 			</Router>

--- a/src/main/psk-ui/src/models/learningEvent.ts
+++ b/src/main/psk-ui/src/models/learningEvent.ts
@@ -1,4 +1,3 @@
-import { Moment } from 'moment';
 import { LearningTopic } from './learningTopic';
 import { Worker } from './worker';
 
@@ -6,8 +5,7 @@ export interface LearningEvent {
 	id: number;
 	name: string;
 	description: string;
-	timeFrom: Moment | null;
-	timeTo: Moment | null;
+	dateTimeAt: string;
 	learningTopic: LearningTopic;
 	assignedWorker: Worker | null;
 }

--- a/src/main/psk-ui/src/pages/private/calendar-view/CalendarStyles.css
+++ b/src/main/psk-ui/src/pages/private/calendar-view/CalendarStyles.css
@@ -3,6 +3,7 @@
     margin: 0;
     padding: 0;
 }
+
 .events .ant-badge-status {
     overflow: hidden;
     white-space: nowrap;
@@ -10,13 +11,20 @@
     text-overflow: ellipsis;
     font-size: 12px;
 }
+
 .notes-month {
     text-align: center;
     font-size: 28px;
 }
+
 .notes-month section {
     font-size: 28px;
 }
+
 .myCalendarTitle {
     text-align: start;
+}
+
+.events-cell-wrapper {
+    height: 100%;
 }

--- a/src/main/psk-ui/src/pages/private/calendar-view/index.tsx
+++ b/src/main/psk-ui/src/pages/private/calendar-view/index.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { Calendar, Modal, Button, Typography, Tag, Divider } from 'antd';
-import * as moment from 'moment';
+import { Calendar, Modal, Button, Typography, Tag, Divider, Spin } from 'antd';
+import moment from 'moment';
 
 import { DAY_EVENT_LIST_EMPTY, MY_CALENDAR } from '../../../Constants';
 import { EventForm } from './EventForm';
 import { LearningEvent } from '../../../models/learningEvent';
-import { learningEvents } from '../../../tools/mockData';
+import calendarService from '../../../api/calendar-service';
 
 import './CalendarStyles.css';
 
@@ -21,6 +21,15 @@ const CalendarView: React.FunctionComponent<{}> = () => {
 	);
 	// status type is our example entity
 	const [modalListData, setModalListData] = useState<LearningEvent[]>([]);
+	const [calendarListData, setCalendarListData] = useState<LearningEvent[]>([]);
+	const [isLoading, setLoading] = useState<boolean>(false);
+
+	//component did mount
+	useEffect(() => {
+		loadData(moment()).then(learningEvents =>
+			setCalendarListData(learningEvents)
+		);
+	}, []);
 
 	function handleOnOk(): void {
 		setModalVisibility(false);
@@ -33,37 +42,68 @@ const CalendarView: React.FunctionComponent<{}> = () => {
 	}
 
 	function handleSelect(date?: moment.Moment | undefined): void {
-		console.log(date);
 		setSelectedDate(date);
 		setModalVisibility(true);
 		if (date !== undefined) setModalListData(getListData(date));
 	}
 	// TODO: move DateCellRenderer into its own module when data fetching is implemented
 	function DateCellRenderer(value: moment.Moment): React.ReactNode {
-		const listData = getListData(value);
-
+		//TODO: Rethink colors of calendar cells
 		return (
-			<ul className="events" onClick={() => {
-				console.log(value);
-			}}>
-				{listData.map(item => (
-					<li key={item.id}>
-						<Tag color={item.learningTopic!.color}>{item.name}</Tag>
-					</li>
-				))}
-			</ul>
+			<div className="events-cell-wrapper" onClick={() => handleSelect(value)}>
+				<ul className="events">
+					{getListData(value).map(item => (
+						<li key={item.id}>
+							<Tag color={"red"}>{item.name}</Tag>
+						</li>
+					))}
+				</ul>
+			</div>
 		);
+	}
+
+	function getListData(value: moment.Moment): LearningEvent[] {
+		return calendarListData.filter(learningEvent =>
+			moment(value.toDate()).isSame(learningEvent.dateTimeAt, 'date'));
+	}
+
+	function loadData(value: moment.Moment): Promise<LearningEvent[]> {
+		// fetch by year, month, day (or any arguments based on backend requirements)
+		// console.log(value.year(), value.month(), value.date())
+
+		// example data:
+		setLoading(true);
+		return calendarService.getMonthLearningDays({
+			selectedYear: value.format('Y'),
+			selectedMonth: value.format('M'),
+			workerId: 1 //TODO: use workerID from redux
+		}).then((response) => {
+			setLoading(false);
+			return response;
+		}).catch(() => {
+			//TODO: Notify if failed to get learning events
+			setLoading(false);
+			return [];
+		});
+	}
+
+	function getMonthEvents(value: moment.Moment) {
+		loadData(value).then((learningEvents) => {
+			setCalendarListData(learningEvents);
+		});
 	}
 
 	// TODO: This return is extremely long - refactor it to smaller components or render functions
 	return (
 		<div>
 			<Title level={2} className={'myCalendarTitle'}>{MY_CALENDAR}</Title>
-			<Calendar
-				dateCellRender={DateCellRenderer}
-				monthCellRender={renderMonthCell}
-				onSelect={handleSelect}
-			/>
+			<Spin spinning={isLoading} size="large">
+				<Calendar
+					dateCellRender={DateCellRenderer}
+					monthCellRender={renderMonthCell}
+					onChange={getMonthEvents}
+				/>
+			</Spin>
 			<Modal
 				title={
 					selectedDate === undefined
@@ -87,7 +127,7 @@ const CalendarView: React.FunctionComponent<{}> = () => {
 							<Divider/>
 						</>
 					))}
-				{selectedDate === undefined ? null : getListData(selectedDate).length === 0 ? (
+				{selectedDate === undefined ? null : calendarListData.length === 0 ? (
 					<p>{DAY_EVENT_LIST_EMPTY}</p>
 				) : null}
 				{isFormVisible ? null : (
@@ -106,29 +146,6 @@ const CalendarView: React.FunctionComponent<{}> = () => {
 	);
 };
 // this method will be changed into a get request
-
-function getListData(value: moment.Moment): LearningEvent[] {
-	// fetch by year, month, day (or any arguments based on backend requirements)
-	// console.log(value.year(), value.month(), value.date())
-
-	// example data:
-	let listData: LearningEvent[] = [];
-
-
-	switch (value.date()) {
-	case 8:
-		listData = learningEvents.slice(0, learningEvents.length);
-		break;
-	case 10:
-		listData = learningEvents.slice(0, 2);
-		break;
-	case 15:
-		listData = learningEvents.slice(0, 1);
-		break;
-	default:
-	}
-	return listData;
-}
 
 function getMonthData (value: moment.Moment): number | null {
 	if (value.month() === 8) {

--- a/src/main/psk-ui/src/redux/index.ts
+++ b/src/main/psk-ui/src/redux/index.ts
@@ -10,7 +10,7 @@ import {
 } from 'redux-state-sync';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import { persistStore, persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage'; // defaults to localStorage for web
+import storage from 'redux-persist/lib/storage';
 
 export interface RootState {
 	user: UserState;

--- a/src/main/psk-ui/src/redux/store.ts
+++ b/src/main/psk-ui/src/redux/store.ts
@@ -1,0 +1,3 @@
+import configureStore from './index';
+
+export const store = configureStore();

--- a/src/main/psk-ui/src/tools/mockData.ts
+++ b/src/main/psk-ui/src/tools/mockData.ts
@@ -73,8 +73,7 @@ export const learningEvents: LearningEvent[] = [
 		id: 0,
 		name: 'Building apps with Redux',
 		description: 'Some very very cool description',
-		timeFrom: null,
-		timeTo: null,
+		dateTimeAt: '',
 		learningTopic: {
 			id: 0,
 			name: 'Web topic',
@@ -89,8 +88,7 @@ export const learningEvents: LearningEvent[] = [
 		id: 1,
 		name: 'JPA basics',
 		description: 'Some very very cool description',
-		timeFrom: null,
-		timeTo: null,
+		dateTimeAt: '',
 		learningTopic: {
 			id: 1,
 			name: 'Java topic',
@@ -106,8 +104,7 @@ export const learningEvents: LearningEvent[] = [
 		id: 2,
 		name: 'Automated testing',
 		description: 'Learning automated testing with selenium and webdriver',
-		timeFrom: null,
-		timeTo: null,
+		dateTimeAt: '',
 		learningTopic: {
 			id: 2,
 			name: 'Testing',

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,8 @@
-spring.datasource.url=jdbc:h2:file:~/testdb;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.url=jdbc:h2:file:~/devbridgeCalendarDB;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
 
 spring.h2.console.enabled=true

--- a/src/test/java/com/VU/PSKProject/PskProjectApplicationTests.java
+++ b/src/test/java/com/VU/PSKProject/PskProjectApplicationTests.java
@@ -1,7 +1,15 @@
 package com.VU.PSKProject;
 
+import com.VU.PSKProject.Entity.LearningDay;
+import com.VU.PSKProject.Entity.Worker;
+import com.VU.PSKProject.Service.Mapper.LearningDayMapper;
+import com.VU.PSKProject.Service.Model.LearningDayDTO;
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.sql.Timestamp;
 
 @SpringBootTest
 class PskProjectApplicationTests {
@@ -9,5 +17,49 @@ class PskProjectApplicationTests {
 	@Test
 	void contextLoads() {
 	}
+
+	private ModelMapper modelMapper = new ModelMapper();
+
+	@Test
+	public void whenConvertLearningDayEntityToLearningDayDto_thenCorrect() {
+		LearningDay learningDay = new LearningDay();
+		Worker worker = new Worker();
+		LearningDayMapper learningDayMapper = new LearningDayMapper();
+
+		worker.setId(1L);
+		worker.setConsecutiveLearningDayLimit(5);
+		worker.setGoals(null);
+		worker.setManagedTeam(null);
+		worker.setName("A");
+		worker.setSurname("B");
+		worker.setWorkingTeam(null);
+
+		learningDay.setId(1L);
+		learningDay.setAssignee(worker);
+		learningDay.setComment("Java");
+		learningDay.setName("Java");
+		learningDay.setDateTimeAt(Timestamp.valueOf("2020-05-03 00:00:00"));
+
+		LearningDayDTO learningDayDTO = modelMapper.map(learningDay, LearningDayDTO.class);
+
+		Assert.assertEquals(learningDay.getDateTimeAt(), learningDayDTO.getDateTimeAt());
+		Assert.assertEquals(learningDay.getId(), learningDayDTO.getId());
+		Assert.assertEquals(learningDay.getComment(), learningDayDTO.getComment());
+		Assert.assertEquals(learningDay.getAssignee().getId(), learningDayDTO.getAssignee().getId());
+		Assert.assertEquals(learningDay.getName(), learningDayDTO.getName());
+	}
+
+	/*@Test
+	public void whenConvertPostDtoToPostEntity_thenCorrect() {
+		PostDto postDto = new PostDto();
+		postDto.setId(1L);
+		postDto.setTitle(randomAlphabetic(6));
+		postDto.setUrl("www.test.com");
+
+		Post post = modelMapper.map(postDto, Post.class);
+		assertEquals(postDto.getId(), post.getId());
+		assertEquals(postDto.getTitle(), post.getTitle());
+		assertEquals(postDto.getUrl(), post.getUrl());
+	}*/
 
 }


### PR DESCRIPTION
Upon entering my calendar view, a backend call will now be made to get the learning days of the month in view for current logged in worker.

For now workerID is hardcoded, it should be stored in redux and used in the request. Decided to skip this, as it is related to user entity having it's worker ID. On login we should get worker ID from backend and store it in redux.

Also added:
 - Frontend API calls now append current login JWT to each request
 - Model mapper dependency for easy conversion of Entity -> DTO and vice versa.
 - Unit test for conversion of LearningDay to DTO
 - H2 config updated - should now save DB on exit
